### PR TITLE
fetch/refetch entity on attach - this is required if a component is d…

### DIFF
--- a/store/entity-behavior.html
+++ b/store/entity-behavior.html
@@ -52,9 +52,14 @@
 			this._entityChangedHandler = this._entityChanged.bind(this);
 		},
 
+		attached: function() {
+			this._fetchEntity(this.href, this.token);
+		},
+
 		detached: function() {
 			if (this.removeListener) {
 				this.removeListener();
+				this.removeListener = null;
 			}
 		},
 


### PR DESCRIPTION
…etached and subsequently reattached e.g. due to a drag and drop operation.

Here it is just calling _fetchEntity manually. Can't decide if that is a bit hacky or not. As on initial render it will cause _fetchEntity to be called twice probably. Once due to the observer and once due to the attach.
Possibly a better approach would be to force the observer to refire? e.g. by setting the href to null and then back again if it has a value?