### PR TITLE
Clean up JSON error handling

### DIFF
--- a/store/siren-action-behavior.html
+++ b/store/siren-action-behavior.html
@@ -102,14 +102,10 @@
 					if (!resp.ok) {
 						var errMsg = resp.statusText + ' response executing ' + opts.method + ' on ' + href + '.';
 						return resp.json().then(function(data) {
-							var obj;
-							try {
-								obj = JSON.parse(data);
-							} catch (e) {
-								throw { string: data, message: errMsg };
-							}
-							throw { json: obj, message: errMsg };
-						})
+							throw { json: data, message: errMsg };
+						}, function(data) {
+							throw { string: data, message: errMsg };
+						});
 					}
 					var linkHeader = resp.headers ? resp.headers.get('Link') : null;
 					var links;


### PR DESCRIPTION
It turns out that `json()` does return a JSON object if the string is parsable as such, and else rejects the promise with the string. My test setup last time has led me to believe it might be otherwise. In this case it resulted in `JSON.parse` always throwing an error as it was attempting to parse a JSON object.

I've also used the `then(resolve(), reject())` construct, rather than `then().catch`, since the `catch` would have caught the `throw` from the successful parse.