### PR TITLE
add a siren action task queue to ensure only 1 siren action is active…

### DIFF
--- a/store/action-queue.html
+++ b/store/action-queue.html
@@ -14,7 +14,12 @@
 			var promise = new Promise(function(resolve, reject) {
 				taskRunner = function() {
 					var result = task();
-					result.then(resolve).catch(reject);
+					// result.then(resolve).catch(reject);
+					return result.then(function(res) {
+						resolve(res);
+					}).catch(function(err) {
+						reject(err);
+					});
 				};
 			});
 			this.queueEnd.then(taskRunner).catch(taskRunner);

--- a/store/action-queue.html
+++ b/store/action-queue.html
@@ -1,0 +1,27 @@
+<script>
+(function() {
+	'use strict';
+
+	window.D2L = window.D2L || {};
+	window.D2L.Siren = window.D2L.Siren || {};
+
+	window.D2L.Siren.ActionQueue = {
+		queueEnd: Promise.resolve(),
+
+		// Task needs to be a function that returns a promise
+		enqueue: function(task) {
+			var taskRunner;
+			var promise = new Promise(function(resolve, reject) {
+				taskRunner = function() {
+					var result = task();
+					result.then(resolve).catch(reject);
+				};
+			});
+			this.queueEnd.then(taskRunner).catch(taskRunner);
+			this.queueEnd = promise;
+			return promise;
+		}
+	};
+})();
+
+</script>

--- a/store/action-queue.html
+++ b/store/action-queue.html
@@ -13,8 +13,12 @@
 			var taskRunner;
 			var promise = new Promise(function(resolve, reject) {
 				taskRunner = function() {
-					var result = task();
-					result.then(resolve).catch(reject);
+					try {
+						var result = task();
+						result.then(resolve).catch(reject);
+					} catch (e) {
+						reject(e);
+					}
 				};
 			});
 			this.queueEnd.then(taskRunner).catch(taskRunner);

--- a/store/action-queue.html
+++ b/store/action-queue.html
@@ -14,12 +14,7 @@
 			var promise = new Promise(function(resolve, reject) {
 				taskRunner = function() {
 					var result = task();
-					// result.then(resolve).catch(reject);
-					return result.then(function(res) {
-						resolve(res);
-					}).catch(function(err) {
-						reject(err);
-					});
+					result.then(resolve).catch(reject);
 				};
 			});
 			this.queueEnd.then(taskRunner).catch(taskRunner);

--- a/store/siren-action-behavior.html
+++ b/store/siren-action-behavior.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../../siren-parser-import/siren-parser.html">
 <link rel="import" href="./entity-store.html">
+<link rel="import" href="./action-queue.html">
 
 <script>
 	'use strict';
@@ -128,13 +129,21 @@
 				.catch(function(reason) {
 					self.fire('d2l-siren-entity-save-error', { error: reason });
 					throw reason;
-				})
+				});
 		},
 
 		performSirenAction: function(action, fields) {
+			var self = this;
+			return window.D2L.Siren.ActionQueue.enqueue(function() {
+				return self._performSirenAction(action, fields);
+			});
+		},
+
+		_performSirenAction: function(action, fields) {
 			if (!action) {
 				return Promise.reject(new Error('No action given'));
 			}
+
 			var headers = new Headers();
 			this.token && headers.append('Authorization', 'Bearer ' + this.token);
 

--- a/store/siren-action-behavior.html
+++ b/store/siren-action-behavior.html
@@ -132,11 +132,11 @@
 				});
 		},
 
-		performSirenAction: function(action, fields) {
+		performSirenAction: function(action, fields, immediate) {
 			var self = this;
-			return window.D2L.Siren.ActionQueue.enqueue(function() {
+			return !immediate ? window.D2L.Siren.ActionQueue.enqueue(function() {
 				return self._performSirenAction(action, fields);
-			});
+			}) : self._performSirenAction(action, fields);
 		},
 
 		_performSirenAction: function(action, fields) {

--- a/test/index.html
+++ b/test/index.html
@@ -15,7 +15,8 @@
 		WCT.loadSuites([
 			'./entity-behavior.html',
 			'./entity-store.html',
-			'./siren-action-behavior.html'
+			'./siren-action-behavior.html',
+			'./action-queue.html'
 		]);
 	</script>
 </body>


### PR DESCRIPTION
… at a time to prevent race conditions.

We've periodically seen issues within the d2l-rubric-editor where race conditions can exist between different siren actions causing inconsistent results to be returned.  Currently it is a bit of a free for all, and we just fire off actions in response to user interactions and hope that things will be 'ok'.

This PR is an initial attempt to try and bring about some 'order', but it may be seen as going too far.

I've added a promise based queue, so that each call to performSirenAction is enqueued behind any existing action API requests. Subsequent actions are only executed when the promise from the current action has completely resolved, which includes waiting on any associated link headers for the current action to be fetched.

This definitely can make the UI seem a bit more sluggish, and it's possible we might want to either make the enqueuing behaviour either default to opt-out or make it possible to opt-out.

Thoughts?