### PR TITLE
Add a get method to retrieve entities from store without fetching for scenarios which rely on the entity being in the store.

### DIFF
--- a/store/entity-store.html
+++ b/store/entity-store.html
@@ -141,6 +141,18 @@
 			}
 		},
 
+		get: function(entityId, token) {
+			const lowerCaseToken = token.toLowerCase();
+			const lowerCaseEntityId = entityId.toLowerCase();
+
+			var entity = this._initContainer(this._store, entityId, token);
+			if (entity) {
+				return entity.entity;
+			} else {
+				return null;
+			}
+		},
+
 		update: function(entityId, token, entity) {
 			const lowerCaseToken = token.toLowerCase();
 			const lowerCaseEntityId = entityId.toLowerCase();
@@ -178,13 +190,22 @@
 					expandEntities.push(entity);
 				});
 
-				if (!expandEntity.href && expandEntity.hasLinkByRel('self')) {
-					const href = expandEntity.getLinkByRel('self').href.toLowerCase();
-					if (!entityIndex.has(href)) {
-						entityIndex.add(href);
-						entities.push({
-							key: href,
-							value: expandEntity
+				if (!expandEntity.href) {
+					if (expandEntity.hasLinkByRel('self')) {
+						const href = expandEntity.getLinkByRel('self').href.toLowerCase();
+						if (!entityIndex.has(href)) {
+							entityIndex.add(href);
+							entities.push({
+								key: href,
+								value: expandEntity
+							});
+						}
+					} else if (expandEntity.hasClass('singleton')) {
+						(expandEntity.rel || []).forEach(function(rel) {
+							entities.push({
+								key: rel,
+								value: expandEntity
+							});
 						});
 					}
 				}

--- a/store/entity-store.html
+++ b/store/entity-store.html
@@ -190,22 +190,13 @@
 					expandEntities.push(entity);
 				});
 
-				if (!expandEntity.href) {
-					if (expandEntity.hasLinkByRel('self')) {
-						const href = expandEntity.getLinkByRel('self').href.toLowerCase();
-						if (!entityIndex.has(href)) {
-							entityIndex.add(href);
-							entities.push({
-								key: href,
-								value: expandEntity
-							});
-						}
-					} else if (expandEntity.hasClass('singleton')) {
-						(expandEntity.rel || []).forEach(function(rel) {
-							entities.push({
-								key: rel,
-								value: expandEntity
-							});
+				if (!expandEntity.href && expandEntity.hasLinkByRel('self')) {
+					const href = expandEntity.getLinkByRel('self').href.toLowerCase();
+					if (!entityIndex.has(href)) {
+						entityIndex.add(href);
+						entities.push({
+							key: href,
+							value: expandEntity
 						});
 					}
 				}

--- a/test/entity-store.js
+++ b/test/entity-store.js
@@ -126,6 +126,19 @@ suite('entity-store', function() {
 			window.D2L.Siren.EntityStore.fetch('static-data/rubrics/organizations/text-only/199/groups/176/criteria.json', '');
 		});
 
+		test('expands singleton non-resource entities', function(done) {
+			window.D2L.Siren.EntityStore.fetch('static-data/199.json', '').then(function() {
+				var entity = window.D2L.Siren.EntityStore.get(
+					'https://api.brightspace.com/rels/richtext-editor-config',
+					'');
+				expect(entity.class).to.include.members(['richtext-editor-config']);
+				if (!done.done) {
+					done();
+					done.done = true;
+				}
+			});
+		});
+
 		suite('link header parse', function() {
 
 			test('can parse single link header', function() {

--- a/test/entity-store.js
+++ b/test/entity-store.js
@@ -69,6 +69,24 @@ suite('entity-store', function() {
 			});
 		});
 
+		test('get entity returns null if not in store', function() {
+			var entity = window.D2L.Siren.EntityStore.get('static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/UNKNOWN1.json', '');
+			expect(entity).to.be.null;
+		});
+
+		test('get entity returns entity sync', function(done) {
+			var request = window.D2L.Siren.EntityStore.fetch('static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0.json', '');
+			request.then(function() {
+				var entity = window.D2L.Siren.EntityStore.get('static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/0.json', '');
+				var description = entity && entity.getSubEntityByClass('description').properties.html;
+				expect(description).to.equal('Proper use of grammar');
+				if (!done.done) {
+					done();
+					done.done = true;
+				}
+			});
+		});
+
 		test('handles entity error using listener', function(done) {
 			window.D2L.Siren.EntityStore.addListener(
 				'static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/UNKNOWN1.json',
@@ -124,19 +142,6 @@ suite('entity-store', function() {
 					}
 				});
 			window.D2L.Siren.EntityStore.fetch('static-data/rubrics/organizations/text-only/199/groups/176/criteria.json', '');
-		});
-
-		test('expands singleton non-resource entities', function(done) {
-			window.D2L.Siren.EntityStore.fetch('static-data/199.json', '').then(function() {
-				var entity = window.D2L.Siren.EntityStore.get(
-					'https://api.brightspace.com/rels/richtext-editor-config',
-					'');
-				expect(entity.class).to.include.members(['richtext-editor-config']);
-				if (!done.done) {
-					done();
-					done.done = true;
-				}
-			});
 		});
 
 		suite('link header parse', function() {

--- a/test/static-data/199.json
+++ b/test/static-data/199.json
@@ -19,15 +19,6 @@
                 "text": "",
                 "html": ""
             }
-        },
-        {
-            "class": ["richtext-editor-config", "singleton"],
-            "rel": ["https://api.brightspace.com/rels/richtext-editor-config"],
-            "properties": {
-                "d2l_isf": {
-                    "endpoint": "/d2l/common/dialogs/isf/selectItem.d2l?ou=121222&filterMode=Strict"
-                }
-            }
         }
     ],
     "links": [

--- a/test/static-data/199.json
+++ b/test/static-data/199.json
@@ -19,6 +19,15 @@
                 "text": "",
                 "html": ""
             }
+        },
+        {
+            "class": ["richtext-editor-config", "singleton"],
+            "rel": ["https://api.brightspace.com/rels/richtext-editor-config"],
+            "properties": {
+                "d2l_isf": {
+                    "endpoint": "/d2l/common/dialogs/isf/selectItem.d2l?ou=121222&filterMode=Strict"
+                }
+            }
         }
     ],
     "links": [


### PR DESCRIPTION
We have a requirement in the rubrics editor to be able to utilize/access siren entities that are embedded as a child entity of a resource based entity, but which by themselves are not URI addressable - e.g. they don't have a self link. 

Could not come up with a great way to do this and to integrate it into our entity store. So I'm experimenting with the idea of flagging an entity with a `singleton` class. Entities which don't have an href or a self link href, but do have the singleton class will be added to the entity store keyed by their `rels`. So if you use a unique rel, then you can access the entity.

I've added a specific `get` store method that will not attempt to fetch an entity but just return it if it already exists in the store. This can be used to load these singleton entities.

All feels a bit hacky, but couldn't come up with a better way to access these non-resource based entities and we need something like that to support configuring the HTML editor in rubrics with information that comes from the LMS.