### PR TITLE
Accept token promise

### DIFF
--- a/store/entity-behavior.html
+++ b/store/entity-behavior.html
@@ -25,7 +25,7 @@
 			 * The user access token
 			 */
 			token: {
-				type: String,
+				type: Object,
 			},
 
 			/**
@@ -64,7 +64,7 @@
 		},
 
 		_fetchEntity: function(href, token) {
-			if (!href || typeof token !== 'string') {
+			if (!href || (typeof token !== 'string' && typeof token !== 'function')) {
 				return;
 			}
 			if (this.removeListener) {

--- a/store/entity-behavior.html
+++ b/store/entity-behavior.html
@@ -70,7 +70,10 @@
 			if (this.removeListener) {
 				this.removeListener();
 			}
-			this.removeListener = window.D2L.Siren.EntityStore.addListener(href, token, this._entityChangedHandler);
+			window.D2L.Siren.EntityStore.addListener(href, token, this._entityChangedHandler)
+				.then( function (removeListener) {
+					this.removeListener = removeListener;
+				}.bind(this));
 			window.D2L.Siren.EntityStore.fetch(href, token);
 		},
 

--- a/store/entity-store.html
+++ b/store/entity-store.html
@@ -41,14 +41,14 @@
 
 		_invalidationListeners: new Set(),
 
-		_initContainer: function(map, entityId, token, init) {
-			const lowerCaseToken = token.toLowerCase();
+		_initContainer: function(map, entityId, cacheKey, init) {
+			const lowerCaseCacheKey = cacheKey.toLowerCase();
 			const lowerCaseEntityId = entityId.toLowerCase();
 
-			if (!map.has(lowerCaseToken)) {
-				map.set(lowerCaseToken, new EntityMap());
+			if (!map.has(lowerCaseCacheKey)) {
+				map.set(lowerCaseCacheKey, new EntityMap());
 			}
-			var entityMap = map.get(lowerCaseToken);
+			var entityMap = map.get(lowerCaseCacheKey);
 			if (init && !entityMap.has(lowerCaseEntityId)) {
 				entityMap.set(lowerCaseEntityId, init);
 			}
@@ -133,7 +133,7 @@
 				const cacheKey = resolved.cacheKey;
 				const tokenValue = resolved.tokenValue;
 
-				const lowerCaseToken = cacheKey.toLowerCase();
+				const lowerCaseCacheKey = cacheKey.toLowerCase();
 				const lowerCaseEntityId = entityId.toLowerCase();
 
 				var entity = this._initContainer(this._store, entityId, cacheKey);
@@ -164,14 +164,14 @@
 									listener(entityId, cacheKey, entity);
 								});
 							}
-							return this._store.get(lowerCaseToken).get(lowerCaseEntityId);
+							return this._store.get(lowerCaseCacheKey).get(lowerCaseEntityId);
 						}.bind(this))
 						.catch(function(err) {
 							this.setError(entityId, tokenValue, err);
-							return this._store.get(lowerCaseToken).get(lowerCaseEntityId);
+							return this._store.get(lowerCaseCacheKey).get(lowerCaseEntityId);
 						}.bind(this));
 
-					this._store.get(lowerCaseToken).set(lowerCaseEntityId, {
+					this._store.get(lowerCaseCacheKey).set(lowerCaseEntityId, {
 						status: 'fetching',
 						entity: null,
 						request: request
@@ -194,10 +194,6 @@
 		get: function(entityId, token) {
 			return this._getToken(token).then(function (resolved) {
 				const cacheKey = resolved.cacheKey;
-				const tokenValue = resolved.tokenValue;
-
-				const lowerCaseToken = cacheKey.toLowerCase();
-				const lowerCaseEntityId = entityId.toLowerCase();
 
 				var entity = this._initContainer(this._store, entityId, cacheKey);
 				if (entity) {
@@ -211,16 +207,15 @@
 		update: function(entityId, token, entity) {
 			return this._getToken(token).then(function (resolved) {
 				const cacheKey = resolved.cacheKey;
-				const tokenValue = resolved.tokenValue;
 
-				const lowerCaseToken = cacheKey.toLowerCase();
+				const lowerCaseCacheKey = cacheKey.toLowerCase();
 				const lowerCaseEntityId = entityId.toLowerCase();
 
-				this._initContainer(this._store, lowerCaseEntityId, lowerCaseToken);
+				this._initContainer(this._store, lowerCaseEntityId, lowerCaseCacheKey);
 				return new Promise(function(resolve) {
 					const entities = this.expand(entityId, entity);
 					entities.forEach(function(entity) {
-						this._store.get(lowerCaseToken).set(entity.key.toLowerCase(), {
+						this._store.get(lowerCaseCacheKey).set(entity.key.toLowerCase(), {
 							status: '',
 							entity: entity.value,
 							request: null
@@ -267,15 +262,14 @@
 		setError: function(entityId, token, error) {
 			return this._getToken(token).then(function (resolved) {
 				const cacheKey = resolved.cacheKey;
-				const tokenValue = resolved.tokenValue;
 
-				const lowerCaseToken = cacheKey.toLowerCase();
+				const lowerCaseCacheKey = cacheKey.toLowerCase();
 				const lowerCaseEntityId = entityId.toLowerCase();
 
 				this._initContainer(this._store, entityId, cacheKey);
 				return new Promise(function(resolve) {
 
-					this._store.get(lowerCaseToken).set(lowerCaseEntityId, {
+					this._store.get(lowerCaseCacheKey).set(lowerCaseEntityId, {
 						status: 'error',
 						entity: null,
 						error: error,
@@ -292,7 +286,6 @@
 		removeListener: function(entityId, token, listener) {
 			return this._getToken(token).then(function (resolved) {
 				const cacheKey = resolved.cacheKey;
-				const tokenValue = resolved.tokenValue;
 
 				if (!entityId || typeof cacheKey !== 'string' || typeof listener !== 'function' || !this._listeners) {
 					return;

--- a/store/entity-store.html
+++ b/store/entity-store.html
@@ -56,15 +56,16 @@
 		},
 
 		addListener: function(entityId, token, listener) {
+			this._getToken(token).then(({cacheKey, tokenValue}) => {
+				if (!entityId || (typeof cacheKey !== 'string' && typeof listener !== 'function')) {
+					return;
+				}
 
-			if (!entityId || typeof token !== 'string' || typeof listener !== 'function') {
-				return;
-			}
-
-			this._initContainer(this._listeners, entityId, token, new Set()).add(listener);
-			return function() {
-				this.removeListener(entityId, token, listener);
-			}.bind(this);
+				this._initContainer(this._listeners, entityId, cacheKey, new Set()).add(listener);
+				return function() {
+					this.removeListener(entityId, tokenValue, listener);
+				}.bind(this);
+			})
 		},
 
 		addInvalidationListener: function(listener) {
@@ -75,6 +76,21 @@
 			this._invalidationListeners.delete(listener);
 		},
 
+		_getToken: function(token) {
+			const tokenPromise = (typeof (token) === 'function')
+				? token()
+				: Promise.resolve(token);
+
+			return tokenPromise.then( tokenValue => {
+				const { sub, tenantid, scope, actualsub = 'actual' } = JSON.parse(atob(tokenValue.split('.')[1]).toString())
+				const cacheKey = `${sub}-${tenantid}-${scope}-${actualsub}`;
+
+				return {
+					cacheKey,
+					tokenValue
+				}
+			})
+		},
 		// This newer version of fetch uses d2l-fetch directly so we can set
 		// appropriate headers to bypass caching done by the d2l-fetch middleware chain
 		// The intention is to replace the fetch implementation that uses d2l-fetch-siren-entity-behavior with this
@@ -84,93 +100,99 @@
 		// updating the UI more consistently when dependent entities change as a result of Siren
 		// actions.
 		fetch: function(entityId, token, bypassCache) {
-			const lowerCaseToken = token.toLowerCase();
-			const lowerCaseEntityId = entityId.toLowerCase();
+			return this._getToken(token).then(({cacheKey, tokenValue}) => {
+				const lowerCaseToken = cacheKey.toLowerCase();
+				const lowerCaseEntityId = entityId.toLowerCase();
 
-			var entity = this._initContainer(this._store, entityId, token);
-			if (!entity || bypassCache) {
+				var entity = this._initContainer(this._store, entityId, cacheKey);
+				if (!entity || bypassCache) {
 
-				var headers = new Headers();
-				token && headers.set('Authorization', 'Bearer ' + token);
+					var headers = new Headers();
+					cacheKey && headers.set('Authorization', 'Bearer ' + tokenValue);
 
-				if (bypassCache) {
-					headers.set('pragma', 'no-cache');
-					headers.set('cache-control', 'no-cache');
+					if (bypassCache) {
+						headers.set('pragma', 'no-cache');
+						headers.set('cache-control', 'no-cache');
+					}
+
+					var request = window.d2lfetch.fetch(entityId, {
+						headers: headers
+					})
+						.then((response) => {
+							if (response.ok) {
+								return response.json();
+							}
+							return Promise.reject(response.status);
+						})
+						.then((body) => {
+							var entity = window.D2L.Hypermedia.Siren.Parse(body);
+							this.update(entityId, tokenValue, entity);
+							if (bypassCache) {
+								this._invalidationListeners.forEach((listener) => {
+									listener(entityId, cacheKey, entity);
+								});
+							}
+							return this._store.get(lowerCaseToken).get(lowerCaseEntityId);
+						})
+						.catch((err) => {
+							this.setError(entityId, tokenValue, err);
+							return this._store.get(lowerCaseToken).get(lowerCaseEntityId);
+						});
+
+					this._store.get(lowerCaseToken).set(lowerCaseEntityId, {
+						status: 'fetching',
+						entity: null,
+						request: request
+					});
+
+					return request;
 				}
 
-				var request = window.d2lfetch.fetch(entityId, {
-					headers: headers
-				})
-				.then(function(response) {
-					if (response.ok) {
-						return response.json();
-					}
-					return Promise.reject(response.status);
-				})
-					.then(function(body) {
-						var entity = window.D2L.Hypermedia.Siren.Parse(body);
-						this.update(entityId, token, entity);
-						if (bypassCache) {
-							this._invalidationListeners.forEach(function(listener) {
-								listener(entityId, token, entity);
-							});
-						}
-						return this._store.get(lowerCaseToken).get(lowerCaseEntityId);
-					}.bind(this))
-					.catch(function(err) {
-						this.setError(entityId, token, err);
-						return this._store.get(lowerCaseToken).get(lowerCaseEntityId);
-					}.bind(this));
-
-				this._store.get(lowerCaseToken).set(lowerCaseEntityId, {
-					status: 'fetching',
-					entity: null,
-					request: request
-				});
-
-				return request;
-			}
-
-			if (entity.request) {
-				return entity.request;
-			} else {
-				return new Promise(function(resolve) {
-					this._notify(lowerCaseEntityId, lowerCaseToken, entity.entity);
-					resolve(entity);
-				}.bind(this));
-			}
+				if (entity.request) {
+					return entity.request;
+				} else {
+					return new Promise((resolve) => {
+						this._notify(lowerCaseEntityId, cacheKey, entity.entity);
+						resolve(entity);
+					});
+				}
+			});
 		},
 
 		get: function(entityId, token) {
-			const lowerCaseToken = token.toLowerCase();
-			const lowerCaseEntityId = entityId.toLowerCase();
+			return this._getToken(token).then(({ cacheKey, tokenValue }) => {
+				const lowerCaseToken = cacheKey.toLowerCase();
+				const lowerCaseEntityId = entityId.toLowerCase();
 
-			var entity = this._initContainer(this._store, entityId, token);
-			if (entity) {
-				return entity.entity;
-			} else {
-				return null;
-			}
+				var entity = this._initContainer(this._store, entityId, cacheKey);
+				if (entity) {
+					return entity.entity;
+				} else {
+					return null;
+				}
+			});
 		},
 
 		update: function(entityId, token, entity) {
-			const lowerCaseToken = token.toLowerCase();
-			const lowerCaseEntityId = entityId.toLowerCase();
+			return this._getToken(token).then(({ cacheKey, tokenValue }) => {
+				const lowerCaseToken = cacheKey.toLowerCase();
+				const lowerCaseEntityId = entityId.toLowerCase();
 
-			this._initContainer(this._store, lowerCaseEntityId, lowerCaseToken);
-			return new Promise(function(resolve) {
-				const entities = this.expand(entityId, entity);
-				entities.forEach(function(entity) {
-					this._store.get(lowerCaseToken).set(entity.key.toLowerCase(), {
-						status: '',
-						entity: entity.value,
-						request: null
-					});
-					this._notify(entity.key, token, entity.value);
+				this._initContainer(this._store, lowerCaseEntityId, lowerCaseToken);
+				return new Promise(function(resolve) {
+					const entities = this.expand(entityId, entity);
+					entities.forEach(function(entity) {
+						this._store.get(lowerCaseToken).set(entity.key.toLowerCase(), {
+							status: '',
+							entity: entity.value,
+							request: null
+						});
+						this._notify(entity.key, cacheKey, entity.value);
+					}.bind(this));
+
+					resolve(entity);
 				}.bind(this));
-
-				resolve(entity);
-			}.bind(this));
+			});
 		},
 
 		expand: function(entityId, entity) {
@@ -205,44 +227,46 @@
 		},
 
 		setError: function(entityId, token, error) {
-			const lowerCaseToken = token.toLowerCase();
-			const lowerCaseEntityId = entityId.toLowerCase();
+			return this._getToken(token).then(({ cacheKey, tokenValue }) => {
+				const lowerCaseToken = cacheKey.toLowerCase();
+				const lowerCaseEntityId = entityId.toLowerCase();
 
-			this._initContainer(this._store, entityId, token);
-			return new Promise(function(resolve) {
+				this._initContainer(this._store, entityId, cacheKey);
+				return new Promise(function(resolve) {
 
-				this._store.get(lowerCaseToken).set(lowerCaseEntityId, {
-					status: 'error',
-					entity: null,
-					error: error,
-					request: null
-				});
-				this._notifyError(entityId, token, error);
+					this._store.get(lowerCaseToken).set(lowerCaseEntityId, {
+						status: 'error',
+						entity: null,
+						error: error,
+						request: null
+					});
+					this._notifyError(entityId, cacheKey, error);
 
-				resolve(error);
+					resolve(error);
 
-			}.bind(this));
+				}.bind(this));
+			});
 		},
 
 		removeListener: function(entityId, token, listener) {
+			return this._getToken(token).then(({ cacheKey, tokenValue }) => {
+				if (!entityId || typeof cacheKey !== 'string' || typeof listener !== 'function' || !this._listeners) {
+					return;
+				}
 
-			if (!entityId || typeof token !== 'string' || typeof listener !== 'function' || !this._listeners) {
-				return;
-			}
-
-			this._initContainer(this._listeners, entityId, token, new Set()).delete(listener);
-
+				this._initContainer(this._listeners, entityId, cacheKey, new Set()).delete(listener);
+			});
 		},
 
-		_notify: function(entityId, token, entity) {
-			const listenerSet = this._initContainer(this._listeners, entityId, token, new Set());
+		_notify: function(entityId, cacheKey, entity) {
+			const listenerSet = this._initContainer(this._listeners, entityId, cacheKey, new Set());
 			listenerSet.forEach(function(listener) {
 				listener(entity);
 			});
 		},
 
-		_notifyError: function(entityId, token, error) {
-			const listenerSet = this._initContainer(this._listeners, entityId, token, new Set());
+		_notifyError: function(entityId, cacheKey, error) {
+			const listenerSet = this._initContainer(this._listeners, entityId, cacheKey, new Set());
 			listenerSet.forEach(function(listener) {
 				listener(null, error);
 			});

--- a/store/entity-store.html
+++ b/store/entity-store.html
@@ -88,13 +88,19 @@
 
 			return tokenPromise.then(function(tokenValue) {
 				if( !tokenValue ) {
-					throw new Error('invalid token')
+					return {
+						cacheKey: '',
+						tokenValue: ''
+					}
 				}
 
 				const tokenParts = tokenValue.split('.')
 
 				if( tokenParts.length < 3 ) {
-					throw new Error('invalid token')
+					return {
+						cacheKey: tokenValue,
+						tokenValue: tokenValue
+					}
 				}
 
 				const decoded = JSON.parse(atob(tokenParts[1]).toString());
@@ -134,7 +140,7 @@
 				if (!entity || bypassCache) {
 
 					var headers = new Headers();
-					headers.set('Authorization', 'Bearer ' + tokenValue);
+					tokenValue && headers.set('Authorization', 'Bearer ' + tokenValue);
 
 					if (bypassCache) {
 						headers.set('pragma', 'no-cache');

--- a/store/entity-store.html
+++ b/store/entity-store.html
@@ -56,16 +56,19 @@
 		},
 
 		addListener: function(entityId, token, listener) {
-			this._getToken(token).then(({cacheKey, tokenValue}) => {
+			return this._getToken(token).then(function (resolved) {
+				const cacheKey = resolved.cacheKey;
+				const tokenValue = resolved.tokenValue;
+
 				if (!entityId || (typeof cacheKey !== 'string' && typeof listener !== 'function')) {
 					return;
 				}
 
 				this._initContainer(this._listeners, entityId, cacheKey, new Set()).add(listener);
-				return function() {
+				return (function() {
 					this.removeListener(entityId, tokenValue, listener);
-				}.bind(this);
-			})
+				}).bind(this);
+			}.bind(this))
 		},
 
 		addInvalidationListener: function(listener) {
@@ -81,13 +84,33 @@
 				? token()
 				: Promise.resolve(token);
 
-			return tokenPromise.then( tokenValue => {
-				const { sub, tenantid, scope, actualsub = 'actual' } = JSON.parse(atob(tokenValue.split('.')[1]).toString())
-				const cacheKey = `${sub}-${tenantid}-${scope}-${actualsub}`;
+			const volatileClaims = ['exp', 'iat', 'jti', 'nbf'];
+
+			return tokenPromise.then(function(tokenValue) {
+				if( !tokenValue ) {
+					throw new Error('invalid token')
+				}
+
+				const tokenParts = tokenValue.split('.')
+
+				if( tokenParts.length < 3 ) {
+					throw new Error('invalid token')
+				}
+
+				const decoded = JSON.parse(atob(tokenParts[1]).toString());
+
+				const normalizedClaims = Object.keys(decoded)
+					.filter(function (val) { return volatileClaims.indexOf(val) === -1 })
+					.reduce(function (result, key) {
+						result[key] = decoded[key]
+						return result;
+					}, {})
+
+				const cacheKey = btoa(JSON.stringify(normalizedClaims)).toString('base64');
 
 				return {
-					cacheKey,
-					tokenValue
+					cacheKey: cacheKey,
+					tokenValue: tokenValue
 				}
 			})
 		},
@@ -100,7 +123,10 @@
 		// updating the UI more consistently when dependent entities change as a result of Siren
 		// actions.
 		fetch: function(entityId, token, bypassCache) {
-			return this._getToken(token).then(({cacheKey, tokenValue}) => {
+			return this._getToken(token).then(function(resolved) {
+				const cacheKey = resolved.cacheKey;
+				const tokenValue = resolved.tokenValue;
+
 				const lowerCaseToken = cacheKey.toLowerCase();
 				const lowerCaseEntityId = entityId.toLowerCase();
 
@@ -108,7 +134,7 @@
 				if (!entity || bypassCache) {
 
 					var headers = new Headers();
-					cacheKey && headers.set('Authorization', 'Bearer ' + tokenValue);
+					headers.set('Authorization', 'Bearer ' + tokenValue);
 
 					if (bypassCache) {
 						headers.set('pragma', 'no-cache');
@@ -118,26 +144,26 @@
 					var request = window.d2lfetch.fetch(entityId, {
 						headers: headers
 					})
-						.then((response) => {
+						.then(function(response) {
 							if (response.ok) {
 								return response.json();
 							}
 							return Promise.reject(response.status);
-						})
-						.then((body) => {
+						}.bind(this))
+						.then(function(body) {
 							var entity = window.D2L.Hypermedia.Siren.Parse(body);
 							this.update(entityId, tokenValue, entity);
 							if (bypassCache) {
-								this._invalidationListeners.forEach((listener) => {
+								this._invalidationListeners.forEach(function(listener) {
 									listener(entityId, cacheKey, entity);
 								});
 							}
 							return this._store.get(lowerCaseToken).get(lowerCaseEntityId);
-						})
-						.catch((err) => {
+						}.bind(this))
+						.catch(function(err) {
 							this.setError(entityId, tokenValue, err);
 							return this._store.get(lowerCaseToken).get(lowerCaseEntityId);
-						});
+						}.bind(this));
 
 					this._store.get(lowerCaseToken).set(lowerCaseEntityId, {
 						status: 'fetching',
@@ -151,16 +177,19 @@
 				if (entity.request) {
 					return entity.request;
 				} else {
-					return new Promise((resolve) => {
+					return new Promise(function(resolve) {
 						this._notify(lowerCaseEntityId, cacheKey, entity.entity);
 						resolve(entity);
-					});
+					}.bind(this));
 				}
-			});
+			}.bind(this));
 		},
 
 		get: function(entityId, token) {
-			return this._getToken(token).then(({ cacheKey, tokenValue }) => {
+			return this._getToken(token).then(function (resolved) {
+				const cacheKey = resolved.cacheKey;
+				const tokenValue = resolved.tokenValue;
+
 				const lowerCaseToken = cacheKey.toLowerCase();
 				const lowerCaseEntityId = entityId.toLowerCase();
 
@@ -170,11 +199,14 @@
 				} else {
 					return null;
 				}
-			});
+			}.bind(this));
 		},
 
 		update: function(entityId, token, entity) {
-			return this._getToken(token).then(({ cacheKey, tokenValue }) => {
+			return this._getToken(token).then(function (resolved) {
+				const cacheKey = resolved.cacheKey;
+				const tokenValue = resolved.tokenValue;
+
 				const lowerCaseToken = cacheKey.toLowerCase();
 				const lowerCaseEntityId = entityId.toLowerCase();
 
@@ -192,7 +224,7 @@
 
 					resolve(entity);
 				}.bind(this));
-			});
+			}.bind(this));
 		},
 
 		expand: function(entityId, entity) {
@@ -227,7 +259,10 @@
 		},
 
 		setError: function(entityId, token, error) {
-			return this._getToken(token).then(({ cacheKey, tokenValue }) => {
+			return this._getToken(token).then(function (resolved) {
+				const cacheKey = resolved.cacheKey;
+				const tokenValue = resolved.tokenValue;
+
 				const lowerCaseToken = cacheKey.toLowerCase();
 				const lowerCaseEntityId = entityId.toLowerCase();
 
@@ -245,17 +280,20 @@
 					resolve(error);
 
 				}.bind(this));
-			});
+			}.bind(this));
 		},
 
 		removeListener: function(entityId, token, listener) {
-			return this._getToken(token).then(({ cacheKey, tokenValue }) => {
+			return this._getToken(token).then(function (resolved) {
+				const cacheKey = resolved.cacheKey;
+				const tokenValue = resolved.tokenValue;
+
 				if (!entityId || typeof cacheKey !== 'string' || typeof listener !== 'function' || !this._listeners) {
 					return;
 				}
 
 				this._initContainer(this._listeners, entityId, cacheKey, new Set()).delete(listener);
-			});
+			}.bind(this));
 		},
 
 		_notify: function(entityId, cacheKey, entity) {

--- a/store/entity-store.html
+++ b/store/entity-store.html
@@ -112,7 +112,7 @@
 						return result;
 					}, {})
 
-				const cacheKey = btoa(JSON.stringify(normalizedClaims)).toString('base64');
+				const cacheKey = btoa(JSON.stringify(normalizedClaims));
 
 				return {
 					cacheKey: cacheKey,


### PR DESCRIPTION
Tokens can now be either a string or a promise. We also peek into the token to create a cache key based on the relevant information. This allows us to fetch a fresh token without having to invalidate our cache. It also means we don't need to repaint all of our web components since 'token' is a promise that hasn't changed. 