### PR TITLE
put back query params in cache key as have no impact on rubrics canon…

### DIFF
--- a/store/entity-store.js
+++ b/store/entity-store.js
@@ -6,8 +6,6 @@ function noop() {}
 window.D2L = window.D2L || {};
 window.D2L.Siren = window.D2L.Siren || {};
 
-
-
 function checkResponse(response) {
 	if (!response.ok) {
 		return Promise.reject(response.status);

--- a/store/entity-store.js
+++ b/store/entity-store.js
@@ -3,34 +3,10 @@ import SirenParse from 'siren-parser';
 
 function noop() {}
 
-function EntityMap() {
-	this._store = new Map();
-	this._cleanEntityId = function(entityId) {
-		return (entityId || '').split('?')[0];
-	};
-}
-
-EntityMap.prototype.set = function(entityId, value) {
-	this._store.set(this._cleanEntityId(entityId), value);
-	return this;
-};
-
-EntityMap.prototype.get = function(entityId) {
-	return this._store.get(this._cleanEntityId(entityId));
-};
-
-EntityMap.prototype.has = function(entityId) {
-	return this._store.has(this._cleanEntityId(entityId));
-};
-
-EntityMap.prototype.delete = function(entityId) {
-	return this._store.delete(this._cleanEntityId(entityId));
-};
-
 window.D2L = window.D2L || {};
 window.D2L.Siren = window.D2L.Siren || {};
 
-window.D2L.Siren.EntityMap = EntityMap;
+
 
 function checkResponse(response) {
 	if (!response.ok) {
@@ -56,7 +32,7 @@ window.D2L.Siren.EntityStore = {
 		const lowerCaseEntityId = entityId.toLowerCase();
 
 		if (!map.has(lowerCaseCacheKey)) {
-			map.set(lowerCaseCacheKey, new EntityMap());
+			map.set(lowerCaseCacheKey, new Map());
 		}
 		const entityMap = map.get(lowerCaseCacheKey);
 		if (init && !entityMap.has(lowerCaseEntityId)) {

--- a/test/entity-store.html
+++ b/test/entity-store.html
@@ -5,14 +5,13 @@
 		<title>d2l-rubric test</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="../../@babel/polyfill/browser.js"></script>
 		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 
 		<!-- For IE11 -->
 		<script src="../../lie/dist/lie.polyfill.min.js"></script>
 		<!-- For IE11 -->
 		<script src="../../whatwg-fetch/fetch.js"></script>
-		
+
 		<script src="../../wct-browser-legacy/browser.js"></script>
 		<script src="./utilities/fetch-siren-entity-whitelist.js"></script>
 		<script type="module" src="../store/entity-store.js"></script>

--- a/test/entity-store.js
+++ b/test/entity-store.js
@@ -288,7 +288,7 @@ suite('entity-store', function() {
 			});
 		});
 
-		suite.only('canonical entity tests', () => {
+		suite('canonical entity tests', () => {
 
 			var fetch;
 			var origFetch;
@@ -329,7 +329,7 @@ suite('entity-store', function() {
 				window.D2L.Siren.EntityStore.fetch('static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json?foo=bar', '');
 			});
 
-			test.only('can fetch leaf entity that contains canonical self relation', function(done) {
+			test('can fetch leaf entity that contains canonical self relation', function(done) {
 				fetch.withArgs('static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json?foo=bar').returns(
 					new Promise(function(resolve) {
 						origFetch.apply(window.d2lfetch, ['static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json']).then(function(response) {

--- a/test/index.html
+++ b/test/index.html
@@ -10,7 +10,7 @@
 	<script src="../../lie/dist/lie.polyfill.min.js"></script>
 	<!-- For IE11 -->
 	<script src="../../whatwg-fetch/fetch.js"></script>
-	
+
 	<script src="../../wct-browser-legacy/browser.js"></script>
 </head>
 

--- a/test/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json
+++ b/test/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json
@@ -1,0 +1,91 @@
+{
+    "class": [
+        "criterion-cell"
+    ],
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "Proper use of grammar should allow query parameters",
+                "html": "Proper use of grammar should allow query parameters"
+            },
+            "actions": [
+              {
+                "name": "update",
+                "method": "PUT",
+                "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json?foo=bar",
+                "fields": [
+                  {
+                    "type": "text",
+                    "name": "description",
+                    "value": "Proper use of grammar should allow query parameters"
+                  },
+                  {
+                    "type": "hidden",
+                    "name": "feedback",
+                    "value": "5 stars for proper use of grammar!"
+                  }
+                ]
+              }
+            ]
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "5 stars for proper use of grammar!",
+                "html": "5 stars for proper use of grammar!"
+            },
+            "actions": [
+              {
+                "name": "update",
+                "method": "PUT",
+                "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json?foo=bar",
+                "fields": [
+                  {
+                    "type": "hidden",
+                    "name": "description",
+                    "value": "Proper use of grammar should allow query parameters"
+                  },
+                  {
+                    "type": "text",
+                    "name": "feedback",
+                    "value": "5 stars for proper use of grammar!"
+                  }
+                ]
+              }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1476.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json?foo=bar"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+        }
+    ]
+}

--- a/test/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json
+++ b/test/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json
@@ -1,0 +1,91 @@
+{
+    "class": [
+        "criterion-cell"
+    ],
+    "entities": [
+        {
+            "class": [
+                "richtext",
+                "description"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "Proper use of grammar should allow query parameters",
+                "html": "Proper use of grammar should allow query parameters"
+            },
+            "actions": [
+              {
+                "name": "update",
+                "method": "PUT",
+                "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json?foo=bar",
+                "fields": [
+                  {
+                    "type": "text",
+                    "name": "description",
+                    "value": "Proper use of grammar should allow query parameters"
+                  },
+                  {
+                    "type": "hidden",
+                    "name": "feedback",
+                    "value": "5 stars for proper use of grammar!"
+                  }
+                ]
+              }
+            ]
+        },
+        {
+            "class": [
+                "richtext",
+                "feedback"
+            ],
+            "rel": [
+                "item"
+            ],
+            "properties": {
+                "text": "5 stars for proper use of grammar!",
+                "html": "5 stars for proper use of grammar!"
+            },
+            "actions": [
+              {
+                "name": "update",
+                "method": "PUT",
+                "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json?foo=bar",
+                "fields": [
+                  {
+                    "type": "hidden",
+                    "name": "description",
+                    "value": "Proper use of grammar should allow query parameters"
+                  },
+                  {
+                    "type": "text",
+                    "name": "feedback",
+                    "value": "5 stars for proper use of grammar!"
+                  }
+                ]
+              }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://rubrics.api.brightspace.com/rels/level"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/levels/1476.json"
+        },
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json"
+        },
+        {
+            "rel": [
+                "up"
+            ],
+            "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json"
+        }
+    ]
+}

--- a/test/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json
+++ b/test/static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json
@@ -19,7 +19,7 @@
               {
                 "name": "update",
                 "method": "PUT",
-                "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json?foo=bar",
+                "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json?foo=bar",
                 "fields": [
                   {
                     "type": "text",
@@ -51,7 +51,7 @@
               {
                 "name": "update",
                 "method": "PUT",
-                "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/1.json?foo=bar",
+                "href": "static-data/rubrics/organizations/text-only/199/groups/176/criteria/623/2.json?foo=bar",
                 "fields": [
                   {
                     "type": "hidden",


### PR DESCRIPTION
…ical URL handling

After reviewing the code and testing, I discovered that the code is already handling the canonical entity self link relation that rubrics relies on in scenarios where query parameters on URLs don't affect the canonical entity link.

So maybe it was just FUD that we added this query parameter stripping to the original rubrics implementation of the entity store. I tested without it and cannot find any issues. 