### PR TITLE
Reject invalid params

### DIFF
--- a/store/entity-store.js
+++ b/store/entity-store.js
@@ -123,6 +123,9 @@ window.D2L.Siren.EntityStore = {
 	// updating the UI more consistently when dependent entities change as a result of Siren
 	// actions.
 	fetch: function(entityId, token, bypassCache) {
+		if(!entityId) {
+			return Promise.reject(new Error('Cannot fetch undefined entityId'));
+		}
 		return this._getToken(token).then(function(resolved) {
 			const cacheKey = resolved.cacheKey;
 			const tokenValue = resolved.tokenValue;
@@ -197,6 +200,9 @@ window.D2L.Siren.EntityStore = {
 	},
 
 	update: function(entityId, token, entity) {
+		if(!entityId) {
+			return Promise.reject(new Error('Cannot fetch undefined entityId'));
+		}
 		return this._getToken(token).then(function(resolved) {
 			const cacheKey = resolved.cacheKey;
 			const lowerCaseEntityId = entityId.toLowerCase();

--- a/store/entity-store.js
+++ b/store/entity-store.js
@@ -123,7 +123,7 @@ window.D2L.Siren.EntityStore = {
 	// updating the UI more consistently when dependent entities change as a result of Siren
 	// actions.
 	fetch: function(entityId, token, bypassCache) {
-		if(!entityId) {
+		if (!entityId) {
 			return Promise.reject(new Error('Cannot fetch undefined entityId'));
 		}
 		return this._getToken(token).then(function(resolved) {
@@ -200,7 +200,7 @@ window.D2L.Siren.EntityStore = {
 	},
 
 	update: function(entityId, token, entity) {
-		if(!entityId) {
+		if (!entityId) {
 			return Promise.reject(new Error('Cannot fetch undefined entityId'));
 		}
 		return this._getToken(token).then(function(resolved) {

--- a/test/entity-store.js
+++ b/test/entity-store.js
@@ -151,19 +151,19 @@ suite('entity-store', function() {
 			window.D2L.Siren.EntityStore.fetch('static-data/rubrics/organizations/text-only/199/groups/176/criteria.json', '');
 		});
 
-		test('fetch rejects undefined entityid', async () => {
+		test('fetch rejects undefined entityid', async() => {
 			try {
 				await window.D2L.Siren.EntityStore.fetch();
-				throw new Error('promise was not rejected')
+				throw new Error('promise was not rejected');
 			} catch (e) {
 				expect(e.message).to.be.equal('Cannot fetch undefined entityId');
 			}
 		});
 
-		test('update rejects undefined entityid', async () => {
+		test('update rejects undefined entityid', async() => {
 			try {
 				await window.D2L.Siren.EntityStore.update();
-				throw new Error('promise was not rejected')
+				throw new Error('promise was not rejected');
 			} catch (e) {
 				expect(e.message).to.be.equal('Cannot fetch undefined entityId');
 			}

--- a/test/entity-store.js
+++ b/test/entity-store.js
@@ -151,6 +151,24 @@ suite('entity-store', function() {
 			window.D2L.Siren.EntityStore.fetch('static-data/rubrics/organizations/text-only/199/groups/176/criteria.json', '');
 		});
 
+		test('fetch rejects undefined entityid', async () => {
+			try {
+				await window.D2L.Siren.EntityStore.fetch();
+				throw new Error('promise was not rejected')
+			} catch (e) {
+				expect(e.message).to.be.equal('Cannot fetch undefined entityId');
+			}
+		});
+
+		test('update rejects undefined entityid', async () => {
+			try {
+				await window.D2L.Siren.EntityStore.update();
+				throw new Error('promise was not rejected')
+			} catch (e) {
+				expect(e.message).to.be.equal('Cannot fetch undefined entityId');
+			}
+		});
+
 		suite('link header parse', function() {
 
 			test('can parse single link header', function() {


### PR DESCRIPTION
`entitystore.fetch` was throwing console errors when we incorporated it into my courses, on this line https://github.com/Brightspace/polymer-siren-behaviors/compare/reject-invalid-params?expand=1#diff-b0c1bbfcefba9a380d3371ab1b1c3bacR133

Feels like we should be more descriptive and protect internals on public functions