### PR TITLE
Add a cache bypass for the entity behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "wct-browser-legacy": "^1.0.1",
     "whatwg-fetch": "^2.0.0"
   },
-  "version": "1.0.6",
+  "version": "1.1.0",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/store/entity-behavior.js
+++ b/store/entity-behavior.js
@@ -37,6 +37,13 @@ D2L.PolymerBehaviors.Siren.EntityBehavior = {
 			notify: true,
 			observer: '_onEntityChanged',
 		},
+		/**
+		* Whether the cache should be disabled for the fetching of this entity
+		*/
+		disableEntityCache: {
+			type: Boolean,
+			value: false
+		},
 
 		_entityChangedHandler: {
 			type: Object,
@@ -83,7 +90,7 @@ D2L.PolymerBehaviors.Siren.EntityBehavior = {
 				}
 
 				this.removeListener = removeListener;
-				window.D2L.Siren.EntityStore.fetch(href, token);
+				window.D2L.Siren.EntityStore.fetch(href, token, this.disableEntityCache);
 			}.bind(this));
 	},
 


### PR DESCRIPTION
When using the `entity-store`'s `fetch` function directly we can set the `bypassCache` parameter, but we had no way to do this for the main `entity` load when using the `entity-behavior`.