### PR TITLE
- Updating siren loading behaviours to handle token getter

### DIFF
--- a/entity-loading-behavior.js
+++ b/entity-loading-behavior.js
@@ -41,7 +41,7 @@ D2L.PolymerBehaviors.Siren.EntityLoadingBehaviorImpl = {
 		}
 		this._oldHref = href;
 		this._oldToken = token;
-		if (typeof href === 'string' && typeof token === 'string') {
+		if (typeof href === 'string' && (typeof token === 'string' || typeof token === 'function')) {
 			window.D2L.Siren.EntityStore.addListener(href, token, this._boundUpdateLoadingState);
 			window.D2L.Siren.EntityStore.fetch(href, token)
 				.then(function(entity) {


### PR DESCRIPTION
[This commit](https://git.dev.d2l/projects/CORE/repos/lms/commits/057b886b7b87bd01bca41627fcee1455a2375161) changed the type of token from string to function by using the new token getter stuff, which caused the loading state to never be updated.   

Also as an aside, I am not fully sure how to back port this to 20.19.12 so any help or docs on how to do that would be appreciated