### PR TITLE
Added an isPending() function to ActionQueue

### DIFF
--- a/store/action-queue.js
+++ b/store/action-queue.js
@@ -15,7 +15,7 @@ window.D2L.Siren.ActionQueue = {
 		_numQueuedActions++;
 		this.queueEnd.then(runTask, runTask);
 		this.queueEnd = promise;
-		promise.finally( function() {
+		promise.finally(function() {
 			_numQueuedActions--;
 		});
 		return promise;

--- a/store/action-queue.js
+++ b/store/action-queue.js
@@ -1,6 +1,8 @@
 window.D2L = window.D2L || {};
 window.D2L.Siren = window.D2L.Siren || {};
 
+var _numQueuedActions = 0;
+
 window.D2L.Siren.ActionQueue = {
 	queueEnd: Promise.resolve(),
 
@@ -10,8 +12,12 @@ window.D2L.Siren.ActionQueue = {
 			queuedResolve = resolve;
 		});
 
+		_numQueuedActions++;
 		this.queueEnd.then(runTask, runTask);
 		this.queueEnd = promise;
+		promise.finally( function() {
+			_numQueuedActions--;
+		});
 		return promise;
 
 		function runTask() {
@@ -19,5 +25,10 @@ window.D2L.Siren.ActionQueue = {
 				resolve(task());
 			}));
 		}
+	},
+
+	isPending: function() {
+		return _numQueuedActions > 0;
 	}
+
 };


### PR DESCRIPTION
Added an isPending() function to ActionQueue

Rationale:
When a user tries to close a dialog window (as in an actual native browser window) using the X, we would like to know if any Siren actions are still pending or in flight, so that we can warn the user that they may lose unsaved changed. Due to the nature of the `unbeforeunload` handler, this check must be done synchronously. Native promises do not have a way for javascript code to check if the promise is pending or not, so I added this method to provide that functionality.