### PR TITLE
Function to remove entity from store.

### DIFF
--- a/store/entity-store.js
+++ b/store/entity-store.js
@@ -262,6 +262,19 @@ window.D2L.Siren.EntityStore = {
 		return entities;
 	},
 
+	remove: function(entityId, token) {
+		if (!entityId) {
+			return Promise.reject(new Error('Cannot fetch undefined entityId'));
+		}
+		return this.getToken(token).then(function(resolved) {
+			const cacheKey = resolved.cacheKey;
+			const lowerCaseEntityId = entityId.toLowerCase();
+			this._initContainer(this._store, entityId, cacheKey);
+			this._store.get(cacheKey).delete(lowerCaseEntityId);
+			this._notify(entityId, cacheKey, null);
+		}.bind(this));
+	},
+
 	setError: function(entityId, token, error) {
 		return this.getToken(token).then(function(resolved) {
 			const cacheKey = resolved.cacheKey;

--- a/test/entity-store.js
+++ b/test/entity-store.js
@@ -171,6 +171,23 @@ suite('entity-store', function() {
 			}
 		});
 
+		test('remove rejects undefined entityid', async() => {
+			try {
+				await window.D2L.Siren.EntityStore.remove();
+				throw new Error('promise was not rejected');
+			} catch (e) {
+				expect(e.message).to.be.equal('Cannot fetch undefined entityId');
+			}
+		});
+
+		test('remove removes item from Entity Store', async() => {
+			const entityId = 'static-data/rubrics/organizations/text-only/199/groups/176/criteria/623.json';
+			await window.D2L.Siren.EntityStore.fetch(entityId, '');
+			expect(await window.D2L.Siren.EntityStore.get(entityId, '')).not.to.be.null;
+			await window.D2L.Siren.EntityStore.remove(entityId, '');
+			expect(await window.D2L.Siren.EntityStore.get(entityId, '')).to.be.null;
+		});
+
 		suite('link header parse', function() {
 
 			test('can parse single link header', function() {


### PR DESCRIPTION
Useful when the response returns null, like in the case of a DELETE API request. The entity store should remove the entity from the entity store.
I have updated the `siren-sdk` `SirenAction` file to call this `remove` function if the response is null.