### PR TITLE
set trackConsoleError to false

### DIFF
--- a/test/action-queue.js
+++ b/test/action-queue.js
@@ -1,4 +1,4 @@
-/* global suite, test, expect, setup, teardown, sinon */
+/* global suite, test, expect, setup, teardown, sinon, WCT */
 
 'use strict';
 
@@ -13,6 +13,7 @@ suite('action-queue', function() {
 	var sandbox;
 
 	setup(function() {
+		WCT._config.trackConsoleError = false;
 		sandbox = sinon.sandbox.create();
 	});
 

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -45,6 +45,5 @@
 				}
 			]
 		}
-	},
-	"trackConsoleError": false
+	}
 }

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -45,5 +45,6 @@
 				}
 			]
 		}
-	}
+	},
+	"trackConsoleError": false
 }


### PR DESCRIPTION
* Promise rejection tests give console.error logs, which causes
  tests to fail

Some background: tests in IE11 started failing in #63. Probably a package update from the cache being invalidated. Some guesses:

1. Previously, the console.error was not being called until the test completed
2. The trackConsoleError was added (probably not, since this was added in 2018)

console.error is being called on Chrome when testing locally, so my guess is 1. I suppose we always had this race condition here. Maybe the way the promise polyfill queues promise rejections changed?

I could either do a deep dive into this, or set trackConsoleError to false, or stub it.