### PR TITLE
catch non-json errors

### DIFF
--- a/store/siren-action-behavior.js
+++ b/store/siren-action-behavior.js
@@ -103,13 +103,10 @@ D2L.PolymerBehaviors.Siren.SirenActionBehaviorImpl = {
 			.then(function(resp) {
 				if (!resp.ok) {
 					var errMsg = resp.statusText + ' response executing ' + opts.method + ' on ' + href + '.';
-					return resp.text()
-					.then(function(text) {
-						try {
-							return JSON.parse(text);
-						} catch (e) {
-							return text;
-						}
+					const clone = resp.clone();
+					return resp.json()
+					.catch(function(error) {
+						return clone.text();
 					})
 					.then(function(data) {
 						throw { json: data, message: errMsg };

--- a/store/siren-action-behavior.js
+++ b/store/siren-action-behavior.js
@@ -113,8 +113,6 @@ D2L.PolymerBehaviors.Siren.SirenActionBehaviorImpl = {
 						})
 						.then(function(data) {
 							throw { json: data, message: errMsg };
-						}, function(data) {
-							throw { string: data, message: errMsg };
 						});
 				}
 				var linkHeader = resp.headers ? resp.headers.get('Link') : null;

--- a/store/siren-action-behavior.js
+++ b/store/siren-action-behavior.js
@@ -103,16 +103,19 @@ D2L.PolymerBehaviors.Siren.SirenActionBehaviorImpl = {
 			.then(function(resp) {
 				if (!resp.ok) {
 					var errMsg = resp.statusText + ' response executing ' + opts.method + ' on ' + href + '.';
-					const clone = resp.clone();
-					return resp.json()
-						.catch(function() {
-							return clone.text();
-						})
-						.then(function(data) {
-							throw { json: data, message: errMsg };
-						}, function(data) {
-							throw { string: data, message: errMsg };
-						});
+					return resp.text()
+					.then(function(text) {
+						try {
+							return JSON.parse(text);
+						} catch (e) {
+							return text;
+						}
+					})
+					.then(function(data) {
+						throw { json: data, message: errMsg };
+					}, function(data) {
+						throw { string: data, message: errMsg };
+					});
 				}
 				var linkHeader = resp.headers ? resp.headers.get('Link') : null;
 				var links;

--- a/store/siren-action-behavior.js
+++ b/store/siren-action-behavior.js
@@ -104,18 +104,18 @@ D2L.PolymerBehaviors.Siren.SirenActionBehaviorImpl = {
 				if (!resp.ok) {
 					var errMsg = resp.statusText + ' response executing ' + opts.method + ' on ' + href + '.';
 					return resp.text()
-					.then(function(text) {
-						try {
-							return JSON.parse(text);
-						} catch (e) {
-							return text;
-						}
-					})
-					.then(function(data) {
-						throw { json: data, message: errMsg };
-					}, function(data) {
-						throw { string: data, message: errMsg };
-					});
+						.then(function(text) {
+							try {
+								return JSON.parse(text);
+							} catch (e) {
+								return text;
+							}
+						})
+						.then(function(data) {
+							throw { json: data, message: errMsg };
+						}, function(data) {
+							throw { string: data, message: errMsg };
+						});
 				}
 				var linkHeader = resp.headers ? resp.headers.get('Link') : null;
 				var links;

--- a/store/siren-action-behavior.js
+++ b/store/siren-action-behavior.js
@@ -105,14 +105,14 @@ D2L.PolymerBehaviors.Siren.SirenActionBehaviorImpl = {
 					var errMsg = resp.statusText + ' response executing ' + opts.method + ' on ' + href + '.';
 					const clone = resp.clone();
 					return resp.json()
-					.catch(function(error) {
-						return clone.text();
-					})
-					.then(function(data) {
-						throw { json: data, message: errMsg };
-					}, function(data) {
-						throw { string: data, message: errMsg };
-					});
+						.catch(function() {
+							return clone.text();
+						})
+						.then(function(data) {
+							throw { json: data, message: errMsg };
+						}, function(data) {
+							throw { string: data, message: errMsg };
+						});
 				}
 				var linkHeader = resp.headers ? resp.headers.get('Link') : null;
 				var links;

--- a/store/siren-action-behavior.js
+++ b/store/siren-action-behavior.js
@@ -103,7 +103,15 @@ D2L.PolymerBehaviors.Siren.SirenActionBehaviorImpl = {
 			.then(function(resp) {
 				if (!resp.ok) {
 					var errMsg = resp.statusText + ' response executing ' + opts.method + ' on ' + href + '.';
-					return resp.json().then(function(data) {
+					return resp.text()
+					.then(function(text) {
+						try {
+							return JSON.parse(text);
+						} catch (e) {
+							return text;
+						}
+					})
+					.then(function(data) {
 						throw { json: data, message: errMsg };
 					}, function(data) {
 						throw { string: data, message: errMsg };


### PR DESCRIPTION
There are instances where the error returned is not a json object, but a bunch of text. This is a hotfix to try to parse the response to text, then to json, and if it fails to parse to json, it would return the text instead.

There doesn't seem to be a way for us to check the type of response or to know anything about it until it is fully parsed. So I figured that parsing to text is safer than JSON and could always be converted to json.