### PR TITLE
US123496 update siren parser dependency version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: node
+node_js: 14
 addons:
   chrome: stable
 script:

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
   "dependencies": {
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
     "fastdom": "^1.0.8",
-    "siren-parser": "^8.0.0"
+    "siren-parser": "^8.4.0"
   }
 }


### PR DESCRIPTION
`node-siren-parser` was updated to be able to handle min/max fields
updating `package-json` to point to this latest version

[US123496](https://rally1.rallydev.com/#/29180338367d/dashboard?detail=%2Fuserstory%2F468303153156&fdp=true?fdp=true): Add Min, Max Properties to ISirenField

https://rally1.rallydev.com/#/29180338367d/dashboard?detail=%2Fuserstory%2F468303153156&fdp=true?fdp=true