### PR TITLE
DE53088 - [CERT 20.23.05] Add extra details on error messages for fetch and extra details to telemetry logged by LX

### DIFF
--- a/store/siren-action-behavior.js
+++ b/store/siren-action-behavior.js
@@ -102,11 +102,11 @@ D2L.PolymerBehaviors.Siren.SirenActionBehaviorImpl = {
 			})
 			.then(function(resp) {
 				if (!resp.ok) {
-					var errMsg = resp.statusText + ' response executing ' + opts.method + ' on ' + href + '.';
+					const errMsg = `${resp.status} response executing ${opts.method} on ${href}`;
 					return resp.json().then(function(data) {
-						throw { json: data, message: errMsg };
+						throw { json: data, message: `${errMsg}: ${JSON.stringify(data)}` };
 					}, function(data) {
-						throw { string: data, message: errMsg };
+						throw { string: data, message: `${errMsg}: ${data}` };
 					});
 				}
 				var linkHeader = resp.headers ? resp.headers.get('Link') : null;

--- a/store/siren-action-behavior.js
+++ b/store/siren-action-behavior.js
@@ -102,11 +102,13 @@ D2L.PolymerBehaviors.Siren.SirenActionBehaviorImpl = {
 			})
 			.then(function(resp) {
 				if (!resp.ok) {
-					const errMsg = `${resp.status} response executing ${opts.method} on ${href}`;
-					return resp.json().then(function(data) {
-						throw { json: data, message: `${errMsg}: ${JSON.stringify(data)}` };
-					}, function(data) {
-						throw { string: data, message: `${errMsg}: ${data}` };
+					resp.text().then(function(data) {
+						return JSON.stringify(data);
+					}).then(function(body) {
+						throw {
+							string: body,
+							message: `${resp.status} response executing ${opts.method} on ${href}: ${body}`
+						};
 					});
 				}
 				var linkHeader = resp.headers ? resp.headers.get('Link') : null;


### PR DESCRIPTION
## Relevant Rally Links

- https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F698542249403


## Description

> **Problem Description - Current Behaviour:**
> The error message and telemetry logging are missing data in 2 files.
>  
>  
> **Problem Description - Expected Behaviour:**
> We want to log details for why the status is blank in these cases.
>  
>  
> **Analysis/Investigation Details:**
> <What analysis/investigation has been done so far to identify that this is a defect?>
>  
> * [SirenAction Fetch](https://search.d2l.dev/xref/Brightspace/polymer-siren-behaviors/store/siren-action-behavior.js?r=b6acd402#103) throws an exception with missing information. `${`[`resp`](https://search.d2l.dev/s?defs=resp&project=BrightspaceHypermediaComponents)`.`[`statusText`](https://search.d2l.dev/s?defs=statusText&project=BrightspaceHypermediaComponents)`}` statusText is incorrect and needs to be corrected to status.
> * SirenAction Fetch error also needs to include the data. The current way it is thrown will not result in the response data being included. Therefore it needs to be refactored into the message itself
> * For [SequencesCompletionTrackingMixin](https://search.d2l.dev/xref/BrightspaceHypermediaComponents/sequences/mixins/d2l-sequences-completion-tracking-mixin.js?r=43645503#82) there are 2 telemetry events being logged
> 	+ 1 needs to have the action serialized correctly
> 	+ both need to be augmented to also include the error message


## Goal/Solution

In `siren-action-behavior.js`:

* `statusText` has been replaced by `status` and the response text is now included in the error message
* A potential bug with handling non-JSON response bodies has been addressed

JSON error response:

![image](https://user-images.githubusercontent.com/89945180/234650178-4fa38309-8e7c-48ee-b737-25fcd13c5d12.png)

Plaintext error response:

![image](https://user-images.githubusercontent.com/89945180/234674925-55455c5d-651f-4e82-bb9c-79d7b04d3356.png)



## Related PRs

- Sequences: https://github.com/BrightspaceHypermediaComponents/sequences/pull/490


## Remaining Work

- [ ] Dev Testing
