### PR TITLE
DE53635 - [LX] Javascript errors starting in 20.23.05

### DIFF
--- a/store/siren-action-behavior.js
+++ b/store/siren-action-behavior.js
@@ -102,7 +102,7 @@ D2L.PolymerBehaviors.Siren.SirenActionBehaviorImpl = {
 			})
 			.then(function(resp) {
 				if (!resp.ok) {
-					resp.text().then(function(data) {
+					return resp.text().then(function(data) {
 						return JSON.stringify(data);
 					}).then(function(body) {
 						throw {


### PR DESCRIPTION
## Relevant Rally Links

- https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F703492176501


## Description

> **Problem Description - Current Behaviour:**
> Many Javascript errors are being logged in LX because a response body is being consumed twice. 
> Dave Lockhart describes what they are seeing in his post in @Team-Phoenix [here](https://d2l.slack.com/archives/CN4CN6W0J/p1685971890249979)
>  
>  
>  
> **Problem Description - Expected Behaviour:**
> This specific error should not be occurring.
>  
>  
> **Analysis/Investigation Details:**
> I have a feeling it is caused by [this PR](https://github.com/Brightspace/polymer-siren-behaviors/pull/76/files) which consumes the response body via reponse.text(). The reponse should be cloned first so it doesn't close the stream on the original body.  
> [Here is some background info.](https://stackoverflow.com/questions/40497859/reread-a-response-body-from-javascripts-fetch)


## Goal/Solution

The issue looks to be a misunderstanding of the [comma operator](https://stackoverflow.com/questions/10284536/return-statement-with-multiple-comma-separated-values/10284572#10284572) from when this code [was last modified](https://github.com/Brightspace/polymer-siren-behaviors/pull/76/files).

When a non-ok status code is encountered, the response body is consumed as part of generating an error message.  Previously, the code would early exit as expected.  When the return was incorrectly removed, the code can now reach line 125 (`return resp.json()`) in a state where the response body has already been consumed.

Adding a return to the offending line prevents line 125 from being reached in the event of an earlier error, fixing the defect:

![image](https://github.com/Brightspace/polymer-siren-behaviors/assets/89945180/10c4ba83-4d95-490a-acff-94fa678022be)


## Remaining Work

- [ ] Dev Testing by another developer
