### PR TITLE
BREAKING CHANGE: upgrade siren-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "@polymer/polymer": "^3.0.0",
     "d2l-fetch": "^2",
     "fastdom": "^1.0.8",
-    "siren-parser": "^8.0.0"
+    "siren-parser": "^9"
   }
 }


### PR DESCRIPTION
⚠️  **DO NOT MERGE yet!** ⚠️ 

As part of the Lit 3 migration, we're taking this opportunity to upgrade everything to `siren-parser` version 9.

We'll hold off on merging this until the Lit 3 migration begins starting May 21st. That will trigger a major version bump for this repo which will then affect downstream repos.