### PR TITLE
fix: revert siren-parser to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "@polymer/polymer": "^3.0.0",
     "d2l-fetch": "^2",
     "fastdom": "^1.0.8",
-    "siren-parser": "^9"
+    "siren-parser": "^8"
   }
 }


### PR DESCRIPTION
Upgrading to v9 apparently wasn't quite as seamless as I originally thought, so reverting back to v8 and we'll have to tackle the `siren-parse` upgrade separately.